### PR TITLE
Make collections imports work in Python 3.10

### DIFF
--- a/examples/pybullet/turtlebot_rovers/streams.py
+++ b/examples/pybullet/turtlebot_rovers/streams.py
@@ -46,7 +46,7 @@ def get_reachable_test(problem, iterations=10, **kwargs):
     initial_confs = {rover: Conf(rover, get_base_joints(rover))
                      for rover in problem.rovers}
     # TODO: restarts -> max_restarts
-    motion_fn = get_motion_fn(problem, restarts=0, max_iterations=iterations, smooth=0, **kwargs)
+    motion_fn = get_motion_fn(problem, restarts=0, iterations=iterations, smooth=0, **kwargs)
     def test(rover, bq):
         bq0 = initial_confs[rover]
         result = motion_fn(rover, bq0, bq)

--- a/pddlstream/algorithms/instantiation.py
+++ b/pddlstream/algorithms/instantiation.py
@@ -1,4 +1,9 @@
-from collections import defaultdict, namedtuple, Sized
+import sys
+from collections import defaultdict, namedtuple
+if sys.version_info >= (3, 10):
+    from collections.abc import Sized
+else:
+    from collections import Sized
 from heapq import heappush, heappop
 from itertools import product
 

--- a/pddlstream/algorithms/skeleton.py
+++ b/pddlstream/algorithms/skeleton.py
@@ -1,7 +1,12 @@
 from __future__ import print_function
 
+import sys
 import time
-from collections import namedtuple, Sized
+from collections import namedtuple
+if sys.version_info >= (3, 10):
+    from collections.abc import Sized
+else:
+    from collections import Sized
 from itertools import count
 from heapq import heappush, heappop
 

--- a/pddlstream/language/conversion.py
+++ b/pddlstream/language/conversion.py
@@ -1,6 +1,10 @@
 from __future__ import print_function
 
-import collections
+import sys
+if sys.version_info >= (3, 10):
+    from collections.abc import Sequence
+else:
+    from collections import Sequence
 from itertools import product
 
 from pddlstream.language.constants import EQ, AND, OR, NOT, CONNECTIVES, QUANTIFIERS, OPERATORS, OBJECTIVES, \
@@ -14,7 +18,7 @@ def replace_expression(parent, fn):
     if prefix == EQ:
         assert(len(parent) == 3)
         value = parent[2]
-        if isinstance(parent[2], collections.Sequence):
+        if isinstance(parent[2], Sequence):
             value = replace_expression(value, fn)
         return prefix, replace_expression(parent[1], fn), value
     elif prefix in (CONNECTIVES + OBJECTIVES):

--- a/pddlstream/language/generator.py
+++ b/pddlstream/language/generator.py
@@ -1,5 +1,11 @@
+import sys
 import time
-from collections import Iterator, namedtuple, deque
+
+from collections import namedtuple, deque
+if sys.version_info >= (3, 10):
+    from collections.abc import Iterator
+else:
+    from collections import Iterator
 from itertools import count
 
 from pddlstream.utils import INF, elapsed_time

--- a/pddlstream/language/stream.py
+++ b/pddlstream/language/stream.py
@@ -1,5 +1,11 @@
+import sys
 import time
-from collections import Counter, Sequence
+
+from collections import Counter
+if sys.version_info >= (3, 10):
+    from collections.abc import Sequence
+else:
+    from collections import Sequence
 
 from pddlstream.algorithms.common import INTERNAL_EVALUATION, add_fact
 from pddlstream.algorithms.downward import make_axiom

--- a/pddlstream/retired/skeleton.py
+++ b/pddlstream/retired/skeleton.py
@@ -1,7 +1,12 @@
 from __future__ import print_function
 
+import sys
 import time
-from collections import namedtuple, Sized
+from collections import namedtuple
+if sys.version_info >= (3, 10):
+    from collections.abc import Sized
+else:
+    from collections import Sized
 from heapq import heappush, heappop, heapreplace
 from operator import itemgetter
 


### PR DESCRIPTION
In Python 3.10, a couple of things were moved out of the `collections` module and into `collections.abc`. See, for example https://stackoverflow.com/questions/72032032/importerror-cannot-import-name-iterable-from-collections-in-python

These slight tweaks make it so that the focused and incremental algorithms work in Python 3.10 without breaking older versions.
 