### PR TITLE
Add pyrobosim to list of external projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ External projects that make use of PDDLStream:
 * Online TAMP - https://github.com/caelan/SS-Replan
 * Automated Construction - https://github.com/caelan/pb-construction
 * Learning + TAMP (LTAMP) - https://github.com/caelan/LTAMP
+* pyrobosim - https://github.com/sea-bass/pyrobosim
 <!--https://github.com/rachelholladay/ftamp-->
 
 ## Algorithms


### PR DESCRIPTION
https://github.com/sea-bass/pyrobosim uses PDDLStream for its TAMP layer, so I wanted to add it in here as well.